### PR TITLE
[CHORE] Change usesCleartextTraffic to false

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".activity.DetailsActivity"
             android:theme="@style/AppTheme2">


### PR DESCRIPTION
### Info
- Changed `usesCleartextTraffic` to false 

### Reason
- The application should support 100% TLS compliance
- iOS has ATS disabled and no issues have come up